### PR TITLE
Add an index.js to simplify require statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npm install slack-client --save
 ## Usage
 ```js
 
-var WebClient = require('../lib/clients/web/client');
-var RtmClient = require('../lib/clients/rtm/client');
+var WebClient = require('slack-client').WebClient;
+var RtmClient = require('slack-client').RtmClient;
 
 var token = '' || process.env.SLACK_API_TOKEN;
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+var WebClient = require('./lib/clients/web/client');
+var RtmClient = require('./lib/clients/rtm/client');
+
+module.exports = {
+	WebClient: WebClient,
+	RtmClient: RtmClient
+};


### PR DESCRIPTION
At the moment you have to require into the module's file structure, e.g. `require('../lib/clients/web/client')`, in order to get the one of the client objects. We should be abstracting this away to simplify usage and to avoid bc breaks if we ever want to change the file structure later.

This PR introduces an index.js file which provides an interface to the module. Usage now looks like this:
```javascript
var WebClient = require('slack-client').WebClient;
var RtmClient = require('slack-client').RtmClient;
```