### PR TITLE
Fixed a bug when handling messages with a `subType`

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -380,7 +380,7 @@ RTMClient.prototype._handleWsMessageViaEventHandler = function(messageType, mess
 
     this.emit(messageType, message);
     if (messageType === RTM_EVENTS.MESSAGE && !isUndefined(message.subtype)) {
-        this.emit(makeMessageEventWithSubtype(subType), message);
+        this.emit(makeMessageEventWithSubtype(message.subType), message);
     }
 };
 


### PR DESCRIPTION
Caused the client to crash when messages with a `subType` were received, e.g. when a bot user was invited to or kicked out of a channel.