### PR TITLE
rtm: Add event and data store support for files

### DIFF
--- a/lib/clients/rtm/event-handlers/file.js
+++ b/lib/clients/rtm/event-handlers/file.js
@@ -1,0 +1,65 @@
+/**
+ * Handlers for all RTM `file_` events.
+ */
+
+var zipObject = require('lodash').zipObject;
+
+var RTM_EVENTS = require('../events/rtm-events').EVENTS;
+var baseChannelHandlers = require('./base-channel');
+var helpers = require('./helpers');
+var models = require('../../../models');
+
+/** {@link https://api.slack.com/events/file_created|file_created} */
+/** {@link https://api.slack.com/events/file_change|file_change} */
+var handleFileCreated = function (dataStore, message) {
+    var file = new models.File(message.file);
+    dataStore.setFile(file);
+};
+
+var persistFileProperty = function (dataStore, messageFile, property, value) {
+    var file = new models.File(messageFile);
+    var existing = dataStore.getFileById(file.id) || file;
+    file[property] = value;
+    dataStore.setFile(file);
+};
+
+/** {@link https://api.slack.com/events/file_shared|file_shared} */
+var handleFileShared = function (dataStore, message) {
+    persistFileProperty(dataStore, message.file, 'isShared', true);
+};
+
+/** {@link https://api.slack.com/events/file_unshared|file_unshared} */
+var handleFileUnshared = function (dataStore, message) {
+    persistFileProperty(dataStore, message.file, 'isShared', false);
+};
+
+/** {@link https://api.slack.com/events/file_public|file_public} */
+var handleFilePublic = function (dataStore, message) {
+    persistFileProperty(dataStore, message.file, 'isPublic', true);
+};
+
+/** {@link https://api.slack.com/events/file_private|file_private} */
+var handleFilePrivate = function (dataStore, message) {
+    var existing = dataStore.getFileById(message.file);
+    if (existing) {
+        existing.isPublic = false;
+    }
+};
+
+/** {@link https://api.slack.com/events/file_deleted|file_deleted} */
+var handleFileDeleted = function (dataStore, message) {
+    dataStore.removeFile(message.fileId);
+};
+
+var handlers = [
+    [RTM_EVENTS.FILE_CREATED, handleFileCreated],
+    [RTM_EVENTS.FILE_CHANGE, handleFileCreated],
+    [RTM_EVENTS.FILE_SHARED, handleFileShared],
+    [RTM_EVENTS.FILE_UNSHARED, handleFileUnshared],
+    [RTM_EVENTS.FILE_PUBLIC, handleFileUnshared],
+    [RTM_EVENTS.FILE_PRIVATE, handleFilePrivate],
+    [RTM_EVENTS.FILE_DELETED, handleFileDeleted]
+];
+
+
+module.exports = zipObject(handlers);

--- a/lib/clients/rtm/event-handlers/index.js
+++ b/lib/clients/rtm/event-handlers/index.js
@@ -17,7 +17,8 @@ var handlerModules = [
     require('./team'),
     require('./user'),
     require('./message'),
-    require('./reactions')
+    require('./reactions'),
+    require('./file')
 ];
 
 

--- a/lib/data-store/data-store.js
+++ b/lib/data-store/data-store.js
@@ -134,6 +134,13 @@ SlackDataStore.prototype.getUnreadCount = function() {
 };
 
 
+/**
+ * Returns the file object matching the supplied id.
+ */
+SlackDataStore.prototype.getFileById = function() {
+};
+
+
 // ###############################################
 // Setters
 // ###############################################
@@ -185,6 +192,12 @@ SlackDataStore.prototype.setBot = function(bot) {
 SlackDataStore.prototype.setTeam = function(team) {
 };
 
+/**
+ * @param {Object} file
+ */
+SlackDataStore.prototype.setFile = function(file) {
+};
+
 
 // ###############################################
 // Deletion methods
@@ -212,6 +225,10 @@ SlackDataStore.prototype.removeBot = function(botId) {
 
 
 SlackDataStore.prototype.removeTeam = function(teamId) {
+};
+
+
+SlackDataStore.prototype.removeFile = function(fileId) {
 };
 
 // ###############################################

--- a/lib/data-store/memory-data-store.js
+++ b/lib/data-store/memory-data-store.js
@@ -51,6 +51,12 @@ var SlackMemoryDataStore = function() {
      * @type {Object}
      */
     this.bots = {};
+
+    /**
+     *
+     * @type {Object}
+     */
+    this.files = {};
 };
 
 inherits(SlackMemoryDataStore, SlackDataStore);
@@ -134,6 +140,12 @@ SlackMemoryDataStore.prototype.getTeamById = function(teamId) {
 };
 
 
+/** @inheritdoc */
+SlackMemoryDataStore.prototype.getFileById = function(fileId) {
+    return this.files[fileId];
+};
+
+
 /**
  * Returns the unread count for all objects: channels, groups etc.
  */
@@ -182,6 +194,12 @@ SlackMemoryDataStore.prototype.setTeam = function(team) {
 };
 
 
+/** @inheritdoc */
+SlackMemoryDataStore.prototype.setFile = function(file) {
+    this.files[file.id] = file;
+};
+
+
 // ###############################################
 // Deletion methods
 // ###############################################
@@ -214,6 +232,12 @@ SlackMemoryDataStore.prototype.removeUser = function(userId) {
 /** @inheritdoc */
 SlackMemoryDataStore.prototype.removeBot = function(botId) {
     delete this.bots[botId];
+};
+
+
+/** @inheritdoc */
+SlackMemoryDataStore.prototype.removeFile = function(fileId) {
+    delete this.files[fileId];
 };
 
 module.exports = SlackMemoryDataStore;

--- a/lib/models/slack/file.js
+++ b/lib/models/slack/file.js
@@ -69,6 +69,7 @@ File.prototype.setProperties = function (opts) {
     this.dms = opts.ims;
     this.reactions = opts.reactions;
 
+    this.isShared = false;
 };
 
 

--- a/test/fixtures/client-events.json
+++ b/test/fixtures/client-events.json
@@ -110,6 +110,259 @@
     "channel": "C0CJ25PDM",
     "user": "U0CJ5PC7L"
   },
+  "file_change": {
+    "type": "file_change",
+    "file": {
+      "id" : "F2147483862",
+      "created" : 1356032811,
+      "timestamp" : 1356032811,
+
+      "name" : "changed.htm",
+      "title" : "My HTML file",
+      "mimetype" : "text\/plain",
+      "filetype" : "text",
+      "pretty_type": "Text",
+      "user" : "U2147483697",
+
+      "mode" : "hosted",
+      "editable" : true,
+      "is_external": false,
+      "external_type": "",
+
+      "size" : 12345,
+
+      "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+      "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+
+      "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+      "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+      "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+      "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+      "thumb_360_w": 100,
+      "thumb_360_h": 100,
+
+      "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+      "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+      "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+      "preview_highlight" : "sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+      "lines" : 123,
+      "lines_more": 118,
+
+      "is_public": true,
+      "public_url_shared": false,
+      "channels": ["C024BE7LT"],
+      "groups": ["G12345"],
+      "ims": ["D12345"],
+      "initial_comment": {},
+      "num_stars": 7,
+      "is_starred": true,
+      "pinned_to": ["C024BE7LT"],
+      "reactions": [
+      {
+          "name": "astonished",
+          "count": 3,
+          "users": [ "U1", "U2", "U3" ]
+      },
+      {
+          "name": "facepalm",
+          "count": 1034,
+          "users": [ "U1", "U2", "U3", "U4", "U5" ]
+      }
+      ]
+    }
+  },
+  "file_shared": {
+    "type": "file_shared",
+    "file": {
+      "id" : "F2147483862",
+      "created" : 1356032811,
+      "timestamp" : 1356032811,
+
+      "name" : "file.htm",
+      "title" : "My HTML file",
+      "mimetype" : "text\/plain",
+      "filetype" : "text",
+      "pretty_type": "Text",
+      "user" : "U2147483697",
+
+      "mode" : "hosted",
+      "editable" : true,
+      "is_external": false,
+      "external_type": "",
+
+      "size" : 12345,
+
+      "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+      "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+
+      "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+      "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+      "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+      "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+      "thumb_360_w": 100,
+      "thumb_360_h": 100,
+
+      "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+      "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+      "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+      "preview_highlight" : "sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+      "lines" : 123,
+      "lines_more": 118,
+
+      "is_public": true,
+      "public_url_shared": false,
+      "channels": ["C024BE7LT"],
+      "groups": ["G12345"],
+      "ims": ["D12345"],
+      "initial_comment": {},
+      "num_stars": 7,
+      "is_starred": true,
+      "pinned_to": ["C024BE7LT"],
+      "reactions": [
+      {
+          "name": "astonished",
+          "count": 3,
+          "users": [ "U1", "U2", "U3" ]
+      },
+      {
+          "name": "facepalm",
+          "count": 1034,
+          "users": [ "U1", "U2", "U3", "U4", "U5" ]
+      }
+      ]
+    }
+  },
+  "file_unshared": {
+    "type": "file_unshared",
+    "file": {
+      "id" : "F2147483862",
+      "created" : 1356032811,
+      "timestamp" : 1356032811,
+
+      "name" : "file.htm",
+      "title" : "My HTML file",
+      "mimetype" : "text\/plain",
+      "filetype" : "text",
+      "pretty_type": "Text",
+      "user" : "U2147483697",
+
+      "mode" : "hosted",
+      "editable" : true,
+      "is_external": false,
+      "external_type": "",
+
+      "size" : 12345,
+
+      "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+      "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+
+      "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+      "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+      "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+      "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+      "thumb_360_w": 100,
+      "thumb_360_h": 100,
+
+      "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+      "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+      "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+      "preview_highlight" : "sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+      "lines" : 123,
+      "lines_more": 118,
+
+      "is_public": true,
+      "public_url_shared": false,
+      "channels": ["C024BE7LT"],
+      "groups": ["G12345"],
+      "ims": ["D12345"],
+      "initial_comment": {},
+      "num_stars": 7,
+      "is_starred": true,
+      "pinned_to": ["C024BE7LT"],
+      "reactions": [
+      {
+          "name": "astonished",
+          "count": 3,
+          "users": [ "U1", "U2", "U3" ]
+      },
+      {
+          "name": "facepalm",
+          "count": 1034,
+          "users": [ "U1", "U2", "U3", "U4", "U5" ]
+      }
+      ]
+    }
+  },
+  "file_created": {
+    "type": "file_created",
+    "file": {
+      "id" : "F2147483862",
+      "created" : 1356032811,
+      "timestamp" : 1356032811,
+
+      "name" : "file.htm",
+      "title" : "My HTML file",
+      "mimetype" : "text\/plain",
+      "filetype" : "text",
+      "pretty_type": "Text",
+      "user" : "U2147483697",
+
+      "mode" : "hosted",
+      "editable" : true,
+      "is_external": false,
+      "external_type": "",
+
+      "size" : 12345,
+
+      "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+      "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+
+      "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+      "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+      "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+      "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+      "thumb_360_w": 100,
+      "thumb_360_h": 100,
+
+      "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+      "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+      "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+      "preview_highlight" : "sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+      "lines" : 123,
+      "lines_more": 118,
+
+      "is_public": true,
+      "public_url_shared": false,
+      "channels": ["C024BE7LT"],
+      "groups": ["G12345"],
+      "ims": ["D12345"],
+      "initial_comment": {},
+      "num_stars": 7,
+      "is_starred": true,
+      "pinned_to": ["C024BE7LT"],
+      "reactions": [
+      {
+          "name": "astonished",
+          "count": 3,
+          "users": [ "U1", "U2", "U3" ]
+      },
+      {
+          "name": "facepalm",
+          "count": 1034,
+          "users": [ "U1", "U2", "U3", "U4", "U5" ]
+      }
+      ]
+    }
+  },
+  "file_private": {
+    "type": "file_private",
+    "file" : "F2147483862"
+  },
+  "file_deleted": {
+    "type": "file_deleted",
+    "file_id" : "F2147483862",
+    "ts": "1448327143.000002"
+  },
   "group_archive": {
     "type": "group_archive",
     "channel": "G0CHZSXFW",


### PR DESCRIPTION
Supports all the regular file events, i.e. no comments yet (can send a separate pull request for that later). Mostly mirrors the Slack API, but also adds an `isShared` flag to the File model.

The `client-events.json` fixture file is starting to grow quite large. Maybe it would be smart to split the events into individual files and have a JS-file combine them? Then the file fixture wouldn't have to be duplicated multiple times, like it is now.