### PR TITLE
Add rtm support for star_added/star_removed events

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -17,7 +17,7 @@ var RTM_EVENTS = require('./events/rtm-events').EVENTS;
 var BaseAPIClient = require('../client');
 var MemoryDataStore = require('../../data-store/memory-data-store');
 var clientEvents = require('./events/client-events');
-var makeMessageEventWithSubtype = require('./helpers').makeMessageEventWithSubtype;
+var makeEventWithSubtype = require('./helpers').makeEventWithSubtype;
 var messageHandlers = require('./event-handlers');
 var parseAPIResponse = require('../helpers').parseAPIResponse;
 var wsSocketFn = require('../rtm/sockets/ws');
@@ -348,7 +348,9 @@ RTMClient.prototype._handleWsMessageInternal = function(messageType, message) {
  */
 RTMClient.prototype._handleWsMessageViaEventHandler = function(messageType, message) {
     if (messageType === RTM_EVENTS.MESSAGE && !isUndefined(message.subtype)) {
-        var handler = messageHandlers[makeMessageEventWithSubtype(message.subtype)];
+        var handler = messageHandlers[makeEventWithSubtype(messageType, message.subtype)];
+    } else if (contains([RTM_EVENTS.STAR_ADDED, RTM_EVENTS.STAR_REMOVED], messageType)) {
+        var handler = messageHandlers[makeEventWithSubtype(messageType, message.type)];
     } else {
         var handler = messageHandlers[messageType];
     }
@@ -367,7 +369,8 @@ RTMClient.prototype._handleWsMessageViaEventHandler = function(messageType, mess
 
         // If there's a custom handler for the message subtype, use that, otherwise default to adding the
         // message to the base channel history
-        handler = handler ? handler : messageHandlers[makeMessageEventWithSubtype('rtm_client_add_message')];
+        handler = handler ?
+            handler : messageHandlers[makeEventWithSubtype(RTM_EVENTS.message, 'rtm_client_add_message')];
     }
 
     if (handler) {
@@ -381,7 +384,7 @@ RTMClient.prototype._handleWsMessageViaEventHandler = function(messageType, mess
 
     this.emit(messageType, message);
     if (messageType === RTM_EVENTS.MESSAGE && !isUndefined(message.subtype)) {
-        this.emit(makeMessageEventWithSubtype(message.subType), message);
+        this.emit(makeEventWithSubtype(messageType, message.subType), message);
     }
 };
 

--- a/lib/clients/rtm/event-handlers/message.js
+++ b/lib/clients/rtm/event-handlers/message.js
@@ -5,8 +5,9 @@
 var findIndex = require('lodash').findIndex;
 var zipObject = require('lodash').zipObject;
 
+var RTM_EVENTS = require('../events/rtm-events').EVENTS;
 var MESSAGE_SUBTYPES = require('../events/rtm-events').MESSAGE_SUBTYPES;
-var makeMessageEventWithSubtype = require('../helpers').makeMessageEventWithSubtype;
+var makeEventWithSubtype = require('../helpers').makeEventWithSubtype;
 var models = require('../../../models');
 
 
@@ -64,16 +65,19 @@ var baseChannelMessageChanged = function(dataStore, message) {
 };
 
 
-var handlers = [
-    [makeMessageEventWithSubtype(MESSAGE_SUBTYPES.MESSAGE_DELETED), baseChannelMessageDeleted],
-    [makeMessageEventWithSubtype(MESSAGE_SUBTYPES.MESSAGE_CHANGED), baseChannelMessageChanged],
-    [makeMessageEventWithSubtype(MESSAGE_SUBTYPES.CHANNEL_JOIN), baseChannelJoin],
-    [makeMessageEventWithSubtype(MESSAGE_SUBTYPES.CHANNEL_LEAVE), baseChannelLeave],
-    [makeMessageEventWithSubtype(MESSAGE_SUBTYPES.GROUP_JOIN), baseChannelJoin],
-    [makeMessageEventWithSubtype(MESSAGE_SUBTYPES.GROUP_LEAVE), baseChannelLeave],
+var subtypeHandlers = [
+    [MESSAGE_SUBTYPES.MESSAGE_DELETED, baseChannelMessageDeleted],
+    [MESSAGE_SUBTYPES.MESSAGE_CHANGED, baseChannelMessageChanged],
+    [MESSAGE_SUBTYPES.CHANNEL_JOIN, baseChannelJoin],
+    [MESSAGE_SUBTYPES.CHANNEL_LEAVE, baseChannelLeave],
+    [MESSAGE_SUBTYPES.GROUP_JOIN, baseChannelJoin],
+    [MESSAGE_SUBTYPES.GROUP_LEAVE, baseChannelLeave],
     // Add in a default handler for all other message subtypes
-    [makeMessageEventWithSubtype('rtm_client_add_message'), addMessageToChannel]
+    ['rtm_client_add_message', addMessageToChannel]
 ];
 
+var handlers = subtypeHandlers.map(function(handler) {
+    return [makeEventWithSubtype(RTM_EVENTS.MESSAGE, handler[0]), handler[1]];
+});
 
 module.exports = zipObject(handlers);

--- a/lib/clients/rtm/event-handlers/stars.js
+++ b/lib/clients/rtm/event-handlers/stars.js
@@ -23,21 +23,39 @@ var persistSharedMessage = function(dataStore, message, isShared) {
     }
 };
 
-/** {@link https://api.slack.com/events/star_added|star_added} */
+var persistSharedChannel = function (dataStore, message, isStarred) {
+    var item = message.item;
+    var channel = dataStore.getChannelGroupOrDMById(item.channel);
+    // As item.channel is only an ID we can only star/unstar
+    // it if we have it in our store:
+    if (channel) {
+        channel.isStarred = isStarred;
+    }
+};
+
 var messageStarred = function (dataStore, message) {
     persistSharedMessage(dataStore, message, true);
 };
 
-/** {@link https://api.slack.com/events/star_removed|star_removed} */
 var messageUnstarred = function (dataStore, message) {
     persistSharedMessage(dataStore, message, false);
 };
 
+var channelStarred = function (dataStore, message) {
+    persistSharedChannel(dataStore, message, true);
+};
+
+var channelUnstarred = function (dataStore, message) {
+    persistSharedChannel(dataStore, message, false);
+};
+
+/** {@link https://api.slack.com/events/star_added|star_added} */
+/** {@link https://api.slack.com/events/star_removed|star_removed} */
 var subtypeHandlers = [
     [RTM_EVENTS.STAR_ADDED, STAR_TYPES.MESSAGE, messageStarred],
     [RTM_EVENTS.STAR_REMOVED, STAR_TYPES.MESSAGE, messageUnstarred],
-    [RTM_EVENTS.STAR_ADDED, STAR_TYPES.CHANNEL, helpers.noopMessage],
-    [RTM_EVENTS.STAR_REMOVED, STAR_TYPES.CHANNEL, helpers.noopMessage],
+    [RTM_EVENTS.STAR_ADDED, STAR_TYPES.CHANNEL, channelStarred],
+    [RTM_EVENTS.STAR_REMOVED, STAR_TYPES.CHANNEL, channelUnstarred],
     [RTM_EVENTS.STAR_ADDED, STAR_TYPES.FILE, helpers.noopMessage],
     [RTM_EVENTS.STAR_REMOVED, STAR_TYPES.FILE, helpers.noopMessage],
     [RTM_EVENTS.STAR_ADDED, STAR_TYPES.FILE_COMMENT, helpers.noopMessage],

--- a/lib/clients/rtm/event-handlers/stars.js
+++ b/lib/clients/rtm/event-handlers/stars.js
@@ -5,13 +5,47 @@
 var zipObject = require('lodash').zipObject;
 
 var RTM_EVENTS = require('../events/rtm-events').EVENTS;
+var STAR_TYPES = require('../events/rtm-events').STAR_TYPES;
+var makeEventWithSubtype = require('../helpers').makeEventWithSubtype;
+var models = require('../../../models');
 var helpers = require('./helpers');
 
+var persistSharedMessage = function(dataStore, message, isShared) {
+    var item = message.item;
+    var channel = dataStore.getChannelGroupOrDMById(item.channel);
+    if (channel) {
+        var channelMessage = channel.getMessageByTs(item.message.ts);
+        if (channelMessage) {
+            channelMessage.isStarred = isShared;
+        } else {
+            channel.addMessage(item.message);
+        }
+    }
+};
 
-var handlers = [
-    [RTM_EVENTS.STAR_ADDED, helpers.noopMessage],
-    [RTM_EVENTS.STAR_REMOVED, helpers.noopMessage]
+/** {@link https://api.slack.com/events/star_added|star_added} */
+var messageStarred = function (dataStore, message) {
+    persistSharedMessage(dataStore, message, true);
+};
+
+/** {@link https://api.slack.com/events/star_removed|star_removed} */
+var messageUnstarred = function (dataStore, message) {
+    persistSharedMessage(dataStore, message, false);
+};
+
+var subtypeHandlers = [
+    [RTM_EVENTS.STAR_ADDED, STAR_TYPES.MESSAGE, messageStarred],
+    [RTM_EVENTS.STAR_REMOVED, STAR_TYPES.MESSAGE, messageUnstarred],
+    [RTM_EVENTS.STAR_ADDED, STAR_TYPES.CHANNEL, helpers.noopMessage],
+    [RTM_EVENTS.STAR_REMOVED, STAR_TYPES.CHANNEL, helpers.noopMessage],
+    [RTM_EVENTS.STAR_ADDED, STAR_TYPES.FILE, helpers.noopMessage],
+    [RTM_EVENTS.STAR_REMOVED, STAR_TYPES.FILE, helpers.noopMessage],
+    [RTM_EVENTS.STAR_ADDED, STAR_TYPES.FILE_COMMENT, helpers.noopMessage],
+    [RTM_EVENTS.STAR_REMOVED, STAR_TYPES.FILE_COMMENT, helpers.noopMessage],
 ];
 
+var handlers = subtypeHandlers.map(function(handler) {
+    return [makeEventWithSubtype(handler[0], handler[1]), handler[2]];
+});
 
 module.exports = zipObject(handlers);

--- a/lib/clients/rtm/events/rtm-events.js
+++ b/lib/clients/rtm/events/rtm-events.js
@@ -95,3 +95,10 @@ module.exports.MESSAGE_SUBTYPES = {
     MESSAGE_CHANGED: 'message_changed',
     MESSAGE_DELETED: 'message_deleted'
 };
+
+module.exports.STAR_TYPES = {
+    MESSAGE: 'message',
+    CHANNEL: 'channel',
+    FILE: 'file',
+    FILE_COMMENT: 'file_comment'
+};

--- a/lib/clients/rtm/helpers.js
+++ b/lib/clients/rtm/helpers.js
@@ -10,9 +10,9 @@ var RTM_EVENTS = require('./events/rtm-events').EVENTS;
  * @param {string} subtype
  * @param {string} delim
  */
-var makeMessageEventWithSubtype = function(subtype, delim) {
-    return [RTM_EVENTS.MESSAGE, subtype].join(delim || '::');
+var makeEventWithSubtype = function(type, subtype, delim) {
+    return [type, subtype].join(delim || '::');
 };
 
 
-module.exports.makeMessageEventWithSubtype = makeMessageEventWithSubtype;
+module.exports.makeEventWithSubtype = makeEventWithSubtype;

--- a/lib/models/node-slack/message.js
+++ b/lib/models/node-slack/message.js
@@ -3,6 +3,7 @@
  */
 
 var findIndex = require('lodash').findIndex;
+var isUndefined = require('lodash').isUndefined;
 var inherits = require('inherits');
 
 var Model = require('../model');
@@ -25,6 +26,7 @@ Message.prototype.setProperties = function(opts) {
     this.ts = opts['ts'];
 
     this.reactions = opts.reactions || [];
+    this.isStarred = isUndefined(opts.isStarred) ? false : opts.isStarred;
 };
 
 

--- a/lib/models/slack/channel.js
+++ b/lib/models/slack/channel.js
@@ -22,6 +22,7 @@ Channel.prototype.setProperties = function (opts) {
     this.isChannel = isUndefined(opts.isChannel) ? true : opts.isChannel;
     this.isGeneral = isUndefined(opts.isGeneral) ? false : opts.isGeneral;
     this.isMember = isUndefined(opts.isMember) ? false : opts.isMember;
+    this.isStarred = isUndefined(opts.isStarred) ? false : opts.isStarred;
 };
 
 

--- a/test/clients/rtm/client-events.js
+++ b/test/clients/rtm/client-events.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var humps = require('humps');
 var lodash = require('lodash');
+var cloneDeep = lodash.cloneDeep;
 
 var RTM_EVENTS = require('../../../lib/clients/rtm/events/rtm-events').EVENTS;
 var MemoryDataStore = require('../../../lib/data-store').MemoryDataStore;
@@ -276,7 +277,25 @@ describe('RTM API Event Handlers', function() {
         describe('`star_xxx` events', function() {
             describe('star_added', function() {
 
-                it('stars a message when a `star_added` message with a `message` property is received');
+                it('stars an existing message when a `star_added` message with a `message` property is received', function() {
+                    var dataStore = getMemoryDataStore();
+                    var channel = dataStore.getChannelById(GENERAL_CHANNEL_ID);
+                    clientEventHandlers['star_added::message'](dataStore, getRTMMessageFixture('star_added::message'));
+                    var message = channel.getMessageByTs('1444959632.000002');
+                    expect(message.isStarred).to.be.true;
+                });
+
+                it('stars and creates a new message when a `star_added` message with a `message` property is received', function() {
+                    var newMessage = cloneDeep(getRTMMessageFixture('star_added::message'));
+                    var newTs = '1734959632.000003'
+                    newMessage.item.message.ts = newTs;
+                    var dataStore = getMemoryDataStore();
+                    var channel = dataStore.getChannelById(GENERAL_CHANNEL_ID);
+                    clientEventHandlers['star_added::message'](dataStore, newMessage);
+                    var message = channel.getMessageByTs(newTs);
+                    expect(message.isStarred).to.be.true;
+                });
+
                 it('stars a file when a `star_added` message with a `message` property is received');
                 it('stars a file_comment when a `star_added` message with a `file_comment` property is received');
                 it('stars a channel when a `star_added` message with a `channel` property is received');
@@ -287,7 +306,26 @@ describe('RTM API Event Handlers', function() {
 
             describe('star_removed', function() {
 
-                it('unstars a message when a `star_removed` message with a `message` property is received');
+                it('unstars a message when a `star_removed` message with a `message` property is received', function () {
+                    var dataStore = getMemoryDataStore();
+                    var channel = dataStore.getChannelById(GENERAL_CHANNEL_ID);
+                    var message = channel.getMessageByTs('1444959632.000002');
+                    message.isStarred = true;
+                    clientEventHandlers['star_removed::message'](dataStore, getRTMMessageFixture('star_removed::message'));
+                    expect(message.isStarred).to.be.false;
+                });
+
+                it('unstars and creates a new message when a `star_added` message with a `message` property is received', function() {
+                    var newMessage = cloneDeep(getRTMMessageFixture('star_removed::message'));
+                    var newTs = '1734959632.000003'
+                    newMessage.item.message.ts = newTs;
+                    var dataStore = getMemoryDataStore();
+                    var channel = dataStore.getChannelById(GENERAL_CHANNEL_ID);
+                    clientEventHandlers['star_removed::message'](dataStore, newMessage);
+                    var message = channel.getMessageByTs(newTs);
+                    expect(message.isStarred).to.be.false;
+                });
+
                 it('unstars a file when a `star_removed` message with a `message` property is received');
                 it('unstars a file_comment when a `star_removed` message with a `file_comment` property is received');
                 it('unstars a channel when a `star_removed` message with a `channel` property is received');

--- a/test/fixtures/client-events.json
+++ b/test/fixtures/client-events.json
@@ -367,6 +367,34 @@
     "reaction": "+1",
     "event_ts": "1450340723.395241"
   },
+  "star_added::message": {
+    "type": "star_added",
+    "user": "U0CJ5PC7L",
+    "item": {
+      "type": "message",
+      "channel": "C0CHZA86Q",
+      "message": {
+        "user": "U0CJ5PC7L",
+        "text": "Cat!",
+        "ts": "1444959632.000002",
+        "is_starred": true
+      }
+    }
+  },
+  "star_removed::message": {
+    "type": "star_removed",
+    "user": "U0CJ5PC7L",
+    "item": {
+      "type": "message",
+      "channel": "C0CHZA86Q",
+      "message": {
+        "user": "U0CJ5PC7L",
+        "text": "Cat!",
+        "ts": "1444959632.000002",
+        "is_starred": false
+      }
+    }
+  },
   "team_domain_change": {
     "type": "team_domain_change",
     "url": "https://sslack-api-test.slack.com",

--- a/test/fixtures/client-events.json
+++ b/test/fixtures/client-events.json
@@ -367,9 +367,19 @@
     "reaction": "+1",
     "event_ts": "1450340723.395241"
   },
+  "star_added::channel": {
+    "type": "star_added",
+    "user": "U0CJ5PC7L",
+    "event_ts": "1450340723.395241",
+    "item": {
+      "type": "channel",
+      "channel": "C0CHZA86Q"
+    }
+  },
   "star_added::message": {
     "type": "star_added",
     "user": "U0CJ5PC7L",
+    "event_ts": "1450340723.395241",
     "item": {
       "type": "message",
       "channel": "C0CHZA86Q",
@@ -381,9 +391,19 @@
       }
     }
   },
+  "star_removed::channel": {
+    "type": "star_removed",
+    "user": "U0CJ5PC7L",
+    "event_ts": "1450340723.395241",
+    "item": {
+      "type": "channel",
+      "channel": "C0CHZA86Q"
+    }
+  },
   "star_removed::message": {
     "type": "star_removed",
     "user": "U0CJ5PC7L",
+    "event_ts": "1450340723.395241",
     "item": {
       "type": "message",
       "channel": "C0CHZA86Q",


### PR DESCRIPTION
Currently supports messages and channels, while files and file comments are noop until the data store supports files (#20).